### PR TITLE
Update VDKDiskImage.cpp

### DIFF
--- a/dragondos/src/VDKDiskImage.cpp
+++ b/dragondos/src/VDKDiskImage.cpp
@@ -103,6 +103,13 @@ bool CVDKDiskImage::Save( const std::string& _filename )
         fwrite( name, 1, uNameLen, pOut );
     }
 
+    // Write padding if header size exceeds fixed header portion plus name length
+    unsigned int paddingNeeded = vdkHead.header_len - (sizeof(vdkHead) + uNameLen);
+    while (paddingNeeded--)
+    {
+        fputc(0, pOut);
+    }
+
     // Save Data
     fwrite( dataBlock, 1, dataBlockSize, pOut );
 


### PR DESCRIPTION
Ensure that where a VDK image has an oversized header containing padding bytes, these are correctly rewritten when outputting changes to the disk content.

Fixes https://github.com/robcfg/retrotools/issues/15
