### PR TITLE
Feature/add jvc dsk image support

### DIFF
--- a/dragondos/CMakeLists.txt
+++ b/dragondos/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(
     ${CMAKE_CURRENT_SOURCE_DIR}/src/DragonDOS_BASIC.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/RawDiskImage.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/VDKDiskImage.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/JVCDiskImage.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/FS_Utils.cpp
 	)
 
@@ -46,6 +47,7 @@ target_sources( dragondosui PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/DragonDOS_UI
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/DragonDOS_ViewFileWindow.cpp
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/RawDiskImage.cpp
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/VDKDiskImage.cpp
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/JVCDiskImage.cpp
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/FS_Utils.cpp
     )
 

--- a/dragondos/src/DragonDOS_FS.h
+++ b/dragondos/src/DragonDOS_FS.h
@@ -145,7 +145,7 @@ public:
     unsigned short int    GetNumberOfFiles() const                        { return (unsigned short int)files.size(); }
     unsigned short int    GetFileIdx      ( std::string _fileName ) const;
     unsigned short int    GetFileEntry    ( std::string _fileName ) const;
-    const CDGNDosFile&    GetFile         ( unsigned short int fileIdx )  { if(fileIdx < files.size()) return files[fileIdx]; return emptyFile; }
+    const CDGNDosFile&    GetFile         ( unsigned short int fileIdx ) const { if(fileIdx < files.size()) return files[fileIdx]; return emptyFile; }
     bool                  InsertFile      ( std::string _fileName, const std::vector<unsigned char>& _data );
     bool                  DeleteFile      ( std::string _fileName );
     bool                  Save            ( std::string _fileName );

--- a/dragondos/src/DragonDOS_UI_Main.cpp
+++ b/dragondos/src/DragonDOS_UI_Main.cpp
@@ -17,6 +17,7 @@
 #include "DragonDOS_UI_Callbacks.h"
 #include "RawDiskImage.h"
 #include "VDKDiskImage.h"
+#include "JVCDiskImage.h"
 
 #ifndef __APPLE__
 #define DRAGONDOSUI_MENUBARHEIGHT 30
@@ -263,16 +264,30 @@ int main( int argc, char** argv )
 
     mainWindow->begin();
 
-    CVDKDiskImage img;
+    // Create disk image handler based on file extension
+    std::string filename = argc > 1 ? argv[1] : "";
+    IDiskImageInterface* pDisk = nullptr;
+    
+    if (!filename.empty()) {
+        std::string ext = filename.substr(filename.find_last_of(".") + 1);
+        if (ext == "jvc") {
+            pDisk = new CJVCDiskImage();
+        } else {
+            pDisk = new CVDKDiskImage();
+        }
+    } else {
+        pDisk = new CVDKDiskImage();
+    }
+    
     CDragonDOS_FS fs;
     
-    img.SetSectorSize( DRAGONDOS_SECTOR_SIZE     );
-    img.SetSectorsNum( DRAGONDOS_SECTORSPERTRACK );
-    img.SetSidesNum  ( 1  );
-    img.SetTracksNum ( 40 );
-    fs.InitDisk( &img );
+    pDisk->SetSectorSize( DRAGONDOS_SECTOR_SIZE     );
+    pDisk->SetSectorsNum( DRAGONDOS_SECTORSPERTRACK );
+    pDisk->SetSidesNum  ( 1  );
+    pDisk->SetTracksNum ( 40 );
+    fs.InitDisk( pDisk );
 
-    context.disk = &img;
+    context.disk = pDisk;
     context.fs = &fs;
 
     CreateMenuBar( mainWindow->w(), DRAGONDOSUI_MENUBARHEIGHT, modifierKey, &context );

--- a/dragondos/src/DragonDOS_ViewFileWindow.cpp
+++ b/dragondos/src/DragonDOS_ViewFileWindow.cpp
@@ -257,6 +257,31 @@ void CDragonDOSViewFileWindow::SetData( const CDragonDOS_FS* _fs, const std::vec
     mBasicView.clear();
     mBasicViewColors.clear();
 
+    // Default to HEX view
+    mViewMode = VM_HEX;
+    if (_selectedFiles.size() == 1) {
+        int fileIdx = _selectedFiles[0];
+        unsigned char fileType = _fs->GetFile(fileIdx).GetFileType();
+        if (fileType == DRAGONDOS_FILETYPE_BASIC) {
+            mViewMode = VM_BASIC;
+        } else if (fileType == DRAGONDOS_FILETYPE_BINARY) {
+            mViewMode = VM_HEX;
+        }
+    }
+
+    // Update radio button state
+    if (mViewMode == VM_BASIC) {
+        mViewAsHexButton->value(0);
+        mViewAsTextButton->value(0);
+        mViewAsBasicButton->value(1);
+        mViewAsImageButton->value(0);
+    } else if (mViewMode == VM_HEX) {
+        mViewAsHexButton->value(1);
+        mViewAsTextButton->value(0);
+        mViewAsBasicButton->value(0);
+        mViewAsImageButton->value(0);
+    }
+
     for( auto file : _selectedFiles )
     {
         std::string fileName = _fs->GetFileName( file );

--- a/dragondos/src/JVCDiskImage.cpp
+++ b/dragondos/src/JVCDiskImage.cpp
@@ -1,0 +1,353 @@
+#include "JVCDiskImage.h"
+#include <stdio.h>
+#include <string.h>
+#include <sstream>
+
+// Standard disk image geometry sizes
+const unsigned int STANDARD_SIZE = 40 * 18 * 256; // Standard DragonDOS disk drive geometry
+const unsigned int EXTENDED_SIZE = 80 * 18 * 256; // Double-sided 40 track or single-sided 80 track disk
+const unsigned int DOUBLE_EXTENDED_SIZE = 80 * 18 * 256 * 2; // Double-sided 80 track disk
+const unsigned int JVC_NORMAL_HEADER_SIZE = 5; // 5 bytes for standard JVC header
+
+CJVCDiskImage::CJVCDiskImage() : dataBlock(nullptr), dataBlockSize(0), tracks(40), headerSize(-1) {}
+
+CJVCDiskImage::~CJVCDiskImage() {
+    if (dataBlock) {
+        delete[] dataBlock;
+    }
+}
+
+bool CJVCDiskImage::CheckDragonDOSFSMetadata(FILE* pIn, unsigned char& sideCount) {
+    unsigned char tracksOnDisk, sectorsPerTrackDisk, tracksComplement, sectorsComplement;
+
+    // Constants
+    const int track = 20;
+    const int sector = 1; // sector 1 (assuming sector numbering starts at 1)
+    const int sectorSize = 256;
+    const int sectorsPerTrack = 18;
+    const int sigOffset = sectorSize - 4; // final 4 bytes of the sector
+
+    // Check first position (single-sided 80 track)
+    long singleSidedOffset = (track * sectorsPerTrack + (sector - 1)) * sectorSize + sigOffset;
+    fseek(pIn, singleSidedOffset, SEEK_SET);
+    fread(&tracksOnDisk, 1, 1, pIn);
+    fread(&sectorsPerTrackDisk, 1, 1, pIn);
+    fread(&tracksComplement, 1, 1, pIn);
+    fread(&sectorsComplement, 1, 1, pIn);
+    // printf("[DEBUG] Single-sided offset: %ld, tracksOnDisk: %u, sectorsPerTrackDisk: %u, tracksComplement: %u, sectorsComplement: %u\n", singleSidedOffset, tracksOnDisk, sectorsPerTrackDisk, tracksComplement, sectorsComplement);
+
+    if (tracksComplement == (unsigned char)~tracksOnDisk && sectorsComplement == (unsigned char)~sectorsPerTrackDisk) {
+        if (tracksOnDisk == 80 && sectorsPerTrackDisk == 18) {
+            sideCount = 1; // Valid: single-sided 80 track
+            return true;
+        }
+    }
+
+    // Check second position (double-sided 40 track)
+    long doubleSidedOffset = (track * sectorsPerTrack * 2 + (sector - 1)) * sectorSize + sigOffset;
+    fseek(pIn, doubleSidedOffset, SEEK_SET);
+    fread(&tracksOnDisk, 1, 1, pIn);
+    fread(&sectorsPerTrackDisk, 1, 1, pIn);
+    fread(&tracksComplement, 1, 1, pIn);
+    fread(&sectorsComplement, 1, 1, pIn);
+    // printf("[DEBUG] Double-sided offset: %ld, tracksOnDisk: %u, sectorsPerTrackDisk: %u, tracksComplement: %u, sectorsComplement: %u\n", doubleSidedOffset, tracksOnDisk, sectorsPerTrackDisk, tracksComplement, sectorsComplement);
+
+    if (tracksComplement == (unsigned char)~tracksOnDisk && sectorsComplement == (unsigned char)~sectorsPerTrackDisk) {
+        if (tracksOnDisk == 40 && sectorsPerTrackDisk == 36) {
+            sideCount = 2; // Valid: double-sided 40 track
+            return true;
+        }
+    }
+
+    return false; // No valid signature/geometry match found
+}
+
+bool CJVCDiskImage::ValidateJVCHeader(const JVCHeader& header) {
+    // Validate header fields with reasonable ranges
+    return (header.sectorsPerTrack == 18) && 
+           (header.sideCount == 1 || header.sideCount == 2) && 
+           (header.sectorSizeCode == 1) && 
+           (header.firstSectorID == 0 || header.firstSectorID == 1) && 
+           (header.sectorAttributeFlag == 0);
+}
+
+bool CJVCDiskImage::Load(const std::string& _filename) {
+    FILE* pIn = fopen(_filename.c_str(), "rb");
+    if (!pIn) {
+        return false;
+    }
+
+    // Get file size
+    fseek(pIn, 0, SEEK_END);
+    unsigned int fileSize = ftell(pIn);
+    fseek(pIn, 0, SEEK_SET);
+
+    // Calculate header length: filesize mod 256
+    headerSize = fileSize % 256;
+    
+    // Initialize header with default values
+    header = JVCHeader();
+    
+    if (headerSize > 0) {
+        // This is a headered image
+        unsigned int dataSize = fileSize - headerSize;
+        
+        // Read the header - use the actual header size, but only read up to 5 bytes max
+        unsigned int bytesToRead = (headerSize > 5) ? 5 : headerSize;
+        
+        if (bytesToRead >= 1) fread(&header.sectorsPerTrack, 1, 1, pIn);
+        if (bytesToRead >= 2) fread(&header.sideCount, 1, 1, pIn);
+        if (bytesToRead >= 3) fread(&header.sectorSizeCode, 1, 1, pIn);
+        if (bytesToRead >= 4) fread(&header.firstSectorID, 1, 1, pIn);
+        if (bytesToRead >= 5) fread(&header.sectorAttributeFlag, 1, 1, pIn);
+        
+        // Validate header
+        if (!ValidateJVCHeader(header)) {
+            headerSize = 0; // Treat as headerless
+            dataSize = fileSize;
+            fseek(pIn, 0, SEEK_SET); // Reset to beginning
+        }
+        
+        // Determine geometry based on data size
+        if (dataSize == STANDARD_SIZE && header.sideCount == 1) {
+            tracks = 40;
+        } else if (dataSize == EXTENDED_SIZE) {
+            // For headerSize <= 1, we can't read side count from header, so check metadata
+            if (headerSize <= 1) {
+                if (!CheckDragonDOSFSMetadata(pIn, header.sideCount)) {
+                    fclose(pIn);
+                    return false;
+                }
+            }
+            tracks = (header.sideCount == 1) ? 80 : 40;
+        } else if (dataSize == DOUBLE_EXTENDED_SIZE && header.sideCount == 2) {
+            tracks = 80;
+        } else {
+            fclose(pIn);
+            return false;
+        }
+        
+        dataBlockSize = dataSize;
+    }
+    if (headerSize == 0) {
+        // This is a headerless image
+        headerSize = 0;
+        dataBlockSize = fileSize;
+        
+        // Determine geometry based on file size
+        if (fileSize == STANDARD_SIZE) {
+            tracks = 40;
+            header.sideCount = 1;
+        } else if (fileSize == EXTENDED_SIZE) {
+            // For headerless images, we must check metadata to determine sidedness
+            if (!CheckDragonDOSFSMetadata(pIn, header.sideCount)) {
+                fclose(pIn);
+                return false;
+            }
+            tracks = (header.sideCount == 1) ? 80 : 40;
+        } else if (fileSize == DOUBLE_EXTENDED_SIZE) {
+            tracks = 80;
+            header.sideCount = 2;
+        } else {
+            fclose(pIn);
+            return false;
+        }
+    }
+
+    // Allocate and read data block
+    dataBlock = new unsigned char[dataBlockSize];
+    if (!dataBlock) {
+        fclose(pIn);
+        return false;
+    }
+
+    // Position file pointer correctly for data reading
+    if (headerSize > 0) {
+        // For headered images, skip the header
+        fseek(pIn, headerSize, SEEK_SET);
+    } else {
+        // For headerless images, we're already at the beginning
+        fseek(pIn, 0, SEEK_SET);
+    }
+    
+    size_t bytesRead = fread(dataBlock, 1, dataBlockSize, pIn);
+    
+    fclose(pIn);
+    fileName = _filename;
+    return true;
+}
+
+bool CJVCDiskImage::Save(const std::string& _filename) {
+    FILE* pOut = fopen(_filename.c_str(), "wb");
+    if (!pOut) {
+        return false;
+    }
+
+    // Write header if the image was loaded with a header
+    if (headerSize > 0) {
+        // Write the header bytes based on the original header size
+        unsigned int bytesToWrite = (headerSize > 5) ? 5 : headerSize;
+        
+        if (bytesToWrite >= 1) fwrite(&header.sectorsPerTrack, 1, 1, pOut);
+        if (bytesToWrite >= 2) fwrite(&header.sideCount, 1, 1, pOut);
+        if (bytesToWrite >= 3) fwrite(&header.sectorSizeCode, 1, 1, pOut);
+        if (bytesToWrite >= 4) fwrite(&header.firstSectorID, 1, 1, pOut);
+        if (bytesToWrite >= 5) fwrite(&header.sectorAttributeFlag, 1, 1, pOut);
+        
+        // If header size is larger than 5 bytes, pad with zeros
+        for (unsigned int i = 5; i < headerSize; ++i) {
+            unsigned char zero = 0;
+            fwrite(&zero, 1, 1, pOut);
+        }
+    }
+
+    // Write data
+    fwrite(dataBlock, 1, dataBlockSize, pOut);
+    fclose(pOut);
+
+    return true;
+}
+
+unsigned int CJVCDiskImage::New(unsigned char uTracks, unsigned char uSides, unsigned char uSecsPerTrack) {
+    tracks = uTracks;
+    header.sideCount = uSides;
+    header.sectorsPerTrack = uSecsPerTrack;
+    header.sectorSizeCode = 1; // Default sector size of 256 bytes
+    header.firstSectorID = 1;
+    header.sectorAttributeFlag = 0;
+
+    // Set header state based on file extension
+    if (fileName.length() >= 4) {
+        std::string ext = fileName.substr(fileName.length() - 4);
+        if (ext == ".jvc") {
+            headerSize = JVC_NORMAL_HEADER_SIZE;
+        } else if (ext == ".dsk") {
+            headerSize = 0;
+        }
+    }
+
+    unsigned int sectorSize = 128 << header.sectorSizeCode;
+    dataBlockSize = header.sectorsPerTrack * header.sideCount * tracks * sectorSize;
+
+    if (dataBlock) {
+        delete[] dataBlock;
+    }
+
+    dataBlock = new unsigned char[dataBlockSize];
+    if (!dataBlock) {
+        return 0;
+    }
+
+    memset(dataBlock, 0, dataBlockSize);
+    return dataBlockSize;
+}
+
+void CJVCDiskImage::SetName(const char* newName) {
+    // JVC format does not support disk names, so this is a no-op
+}
+
+const unsigned char* CJVCDiskImage::GetSector(unsigned int uTrack, unsigned int uSide, unsigned int uSector) const 
+{
+    // Check values
+    if( 0 == dataBlock || uTrack >= tracks || uSide >= header.sideCount || uSector >= header.sectorsPerTrack) return nullptr;
+
+    // Do some math
+    unsigned int uTrackStart = 256 * header.sideCount * header.sectorsPerTrack * uTrack;
+    unsigned int uSectorPos = uTrackStart + (256 * (( uSide * header.sectorsPerTrack ) + uSector));
+
+    return &dataBlock[uSectorPos];
+}
+
+unsigned char* CJVCDiskImage::GetSector(unsigned int uTrack, unsigned int uSide, unsigned int uSector)
+{
+    return const_cast<unsigned char*>(const_cast<const CJVCDiskImage*>(this)->GetSector(uTrack, uSide, uSector));
+}
+
+// IDiskImageInterface required method stubs for CJVCDiskImage
+
+bool CJVCDiskImage::NeedManualSetup() const {
+    return false; // We handle disk geometry automatically
+}
+
+int CJVCDiskImage::GetSidesNum() const {
+    return header.sideCount;
+}
+
+int CJVCDiskImage::GetTracksNum() const {
+    return tracks;
+}
+
+int CJVCDiskImage::GetSectorsNum() const {
+    return header.sectorsPerTrack;
+}
+
+int CJVCDiskImage::GetSectorsNum(size_t _side, size_t _track) const {
+     return header.sectorsPerTrack;
+}
+
+STrackInfo CJVCDiskImage::GetTrackInfo(unsigned int _track, unsigned int _side) const {
+    STrackInfo retVal;
+    retVal.isValid     = (_side < (unsigned int)GetSidesNum()) && (_track < (unsigned int)GetTracksNum());
+    retVal.isFormatted = true;
+    retVal.sectorsNum  = GetSectorsNum();
+    retVal.dataSize    = retVal.sectorsNum * 256;
+    return retVal;
+}
+
+SSectorInfo CJVCDiskImage::GetSectorInfo(unsigned int _track, unsigned int _side, unsigned int _sector) const {
+	SSectorInfo retVal;
+
+	retVal.isValid   = (_side < (unsigned int)GetSidesNum()) && (_track < (unsigned int)GetTracksNum()) && (_sector < (unsigned int)GetSectorsNum());
+	retVal.hasErrors = false;
+	retVal.isInUse   = true;  // FS should check or update this info
+	retVal.isWeak    = false;
+	retVal.copiesNum = 1; // Number of copies of the sector stored
+	retVal.dataSize  = 256;
+
+	return retVal;
+}
+
+const unsigned char* CJVCDiskImage::GetSectorByID(unsigned int uTrack, unsigned int uSide, unsigned int uSector) const
+{
+    return GetSector(uTrack, uSide, uSector);
+}
+
+std::string CJVCDiskImage::GetFileSpec() {
+    return "DSK/JVC disk images \t*.{dsk,jvc}\n";
+}
+
+std::string CJVCDiskImage::GetDiskInfo() {
+    std::string retVal;
+
+    if (fileName.empty()) {
+        return retVal;
+    }
+
+    std::stringstream sstream;
+
+    // Get short filename
+    std::string shortFileName;
+    size_t found = fileName.find_last_of("/\\");
+    if (found) {
+        shortFileName = fileName.substr(found + 1);
+    } else {
+        shortFileName = fileName;
+    }
+
+    // Calculate disk size
+    int diskSize = GetTracksNum() * GetSidesNum() * GetSectorsNum() * 256; // 256 bytes per sector
+
+    // Format header state
+    std::string headerStateStr = (headerSize > 0) ? "With Header" : "Headerless";
+
+    sstream << shortFileName << std::endl << std::endl;
+    sstream << "Format      : " << headerStateStr << std::endl;
+    sstream << "Tracks      : " << GetTracksNum() << std::endl;
+    sstream << "Sides       : " << GetSidesNum() << std::endl;
+    sstream << "Sectors     : " << GetSectorsNum() << std::endl;
+    sstream << "Sector size : 256 bytes" << std::endl;
+    sstream << "Total size  : " << diskSize << " bytes/" << diskSize / 1024 << " KB" << std::endl;
+
+    retVal = sstream.str();
+    return retVal;
+}

--- a/dragondos/src/JVCDiskImage.h
+++ b/dragondos/src/JVCDiskImage.h
@@ -1,0 +1,62 @@
+#ifndef JVC_DISK_IMAGE_H
+#define JVC_DISK_IMAGE_H
+
+#include <string>
+#include "DiskImageInterface.h"
+
+// JVC Header structure with default values
+struct JVCHeader {
+    unsigned char sectorsPerTrack;    // Default: 18
+    unsigned char sideCount;          // Default: 1
+    unsigned char sectorSizeCode;     // Default: 1
+    unsigned char firstSectorID;      // Default: 1
+    unsigned char sectorAttributeFlag; // Default: 0
+    
+    JVCHeader() : sectorsPerTrack(18), sideCount(1), sectorSizeCode(1), firstSectorID(1), sectorAttributeFlag(0) {}
+};
+
+class CJVCDiskImage : public IDiskImageInterface {
+public:
+    CJVCDiskImage();
+    ~CJVCDiskImage();
+
+    // IDiskImageInterface required methods
+    bool Load(const std::string& _filename) override;
+    bool Save(const std::string& _filename) override;
+    unsigned int New(unsigned char uTracks, unsigned char uSides, unsigned char uSecsPerTrack) override;
+
+    int GetSidesNum() const override;
+    int GetTracksNum() const override;
+    int GetSectorsNum() const override;
+    int GetSectorsNum(size_t _side, size_t _track) const override;
+    STrackInfo  GetTrackInfo(unsigned int _track, unsigned int _side) const override;
+    SSectorInfo GetSectorInfo(unsigned int _track, unsigned int _side, unsigned int _sector) const override;
+    const unsigned char* GetSector(unsigned int uTrack, unsigned int uSide, unsigned int uSector) const override;
+    unsigned char* GetSector(unsigned int uTrack, unsigned int uSide, unsigned int uSector) override;
+    const unsigned char* GetSectorByID(unsigned int uTrack, unsigned int uSide, unsigned int uSector) const override;
+    std::string GetFileSpec() override;
+    std::string GetDiskInfo() override;
+    bool NeedManualSetup() const override;
+
+    void SetName(const char* newName);
+    void SetFileName(const std::string& _filename) { fileName = _filename; }
+    void SetHeaderSize(unsigned int size) { headerSize = size; }
+
+    // Add missing GetSectorSize overrides
+    size_t GetSectorSize(unsigned int _track, unsigned int _side, unsigned int _sector) override { return 256; }
+    size_t GetSectorSize() override { return 256; }
+
+    unsigned int GetHeaderSize() const { return headerSize; }
+
+private:
+    bool CheckDragonDOSFSMetadata(FILE* pIn, unsigned char& sideCount);
+    bool ValidateJVCHeader(const JVCHeader& header);
+    unsigned char* dataBlock;
+    unsigned int dataBlockSize;
+    std::string fileName;
+    JVCHeader header;
+    unsigned char tracks;
+    unsigned int headerSize;  // -1 = not yet determined, 0 = headerless, >0 = headered with this size
+};
+
+#endif // JVC_DISK_IMAGE_H 

--- a/dragondos/src/VDKDiskImage.cpp
+++ b/dragondos/src/VDKDiskImage.cpp
@@ -262,11 +262,7 @@ int CVDKDiskImage::GetSectorsNum(size_t _side, size_t _track) const
 
 std::string CVDKDiskImage::GetFileSpec()
 {
-//#if defined(__APPLE__) || defined(WIN32)
-	return "Dragon VDK files\t*.{vdk,dsk}\n"; // Native chooser format.
-//#else
-//	return "Dragon VDK files (*.{vdk})\t";
-//#endif
+    return "Dragon VDK files\t*.vdk\n"; // Native chooser format.
 }
 
 std::string CVDKDiskImage::GetDiskInfo()

--- a/dragondos/src/VDKDiskImage.cpp
+++ b/dragondos/src/VDKDiskImage.cpp
@@ -103,6 +103,13 @@ bool CVDKDiskImage::Save( const std::string& _filename )
         fwrite( name, 1, uNameLen, pOut );
     }
 
+    // Write padding if header size exceeds fixed header portion plus name length
+    unsigned int paddingNeeded = vdkHead.header_len - (sizeof(vdkHead) + uNameLen);
+    while (paddingNeeded--)
+    {
+        fputc(0, pOut);
+    }
+
     // Save Data
     fwrite( dataBlock, 1, dataBlockSize, pOut );
 


### PR DESCRIPTION
Added and integrated a new class to allow support of JVC/DSK files.
Also enabled explicit handling of the 2 different geometries for 360k disks (40 track double sided, and 80 track single sided).
Added initial view type defaulting to the viewing window for binary and basic files.

Feel free to use elements of this code in a revised form if you prefer an alternative class structure to implement.
